### PR TITLE
perf: implement the MultiSet method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.5-0.20221011183528-d4900dc688bf // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/onsi/gomega v1.19.0 // indirect
+	github.com/panjf2000/ants/v2 v2.5.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/alicebob/miniredis/v2 v2.22.0
 	github.com/ethereum/go-ethereum v1.10.23
 	github.com/go-redis/redis/v8 v8.11.5
+	github.com/hashicorp/golang-lru v0.5.5-0.20221011183528-d4900dc688bf
+	github.com/panjf2000/ants/v2 v2.5.0
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2
@@ -19,10 +21,8 @@ require (
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/hashicorp/golang-lru v0.5.5-0.20221011183528-d4900dc688bf // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/onsi/gomega v1.19.0 // indirect
-	github.com/panjf2000/ants/v2 v2.5.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,7 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deckarep/golang-set v1.8.0/go.mod h1:5nI87KwE7wgsBU1F4GKAw2Qod7p5kyS383rP6+o6qqo=
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
@@ -357,6 +358,7 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5/go.mod h1:eCbImbZ95eXtAUIbLAuAVnBnwf83mjf6QIVH8SHYwqQ=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
@@ -412,6 +414,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/supranational/blst v0.3.8-0.20220526154634-513d2456b344/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
@@ -793,6 +797,7 @@ gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/go.sum
+++ b/go.sum
@@ -343,6 +343,8 @@ github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.0.3-0.20180606204148-bd9c31933947/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/panjf2000/ants/v2 v2.5.0 h1:1rWGWSnxCsQBga+nQbA4/iY6VMeNoOIAM0ZWh9u3q2Q=
+github.com/panjf2000/ants/v2 v2.5.0/go.mod h1:cU93usDlihJZ5CfRGNDYsiBYvoilLvBF5Qp/BT2GNRE=
 github.com/paulbellamy/ratecounter v0.2.0/go.mod h1:Hfx1hDpSGoqxkVVpBi/IlYD7kChlfo5C6hzIHwPqfFE=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=

--- a/interface.go
+++ b/interface.go
@@ -16,7 +16,7 @@ type (
 		Size() uint64
 		Get(key uint64, version *Version) ([]byte, error)
 		Set(key uint64, val []byte) error
-		MultiSet(items ...Item) error
+		MultiSet(items []Item) error
 		IsEmpty() bool
 		Root() []byte
 		GetProof(key uint64) (Proof, error)

--- a/interface.go
+++ b/interface.go
@@ -6,11 +6,17 @@
 package bsmt
 
 type (
-	Version          uint64
+	Version uint64
+
+	Item struct {
+		Key uint64
+		Val []byte
+	}
 	SparseMerkleTree interface {
 		Size() uint64
 		Get(key uint64, version *Version) ([]byte, error)
 		Set(key uint64, val []byte) error
+		MultiSet(items ...Item) error
 		IsEmpty() bool
 		Root() []byte
 		GetProof(key uint64) (Proof, error)

--- a/options.go
+++ b/options.go
@@ -7,6 +7,7 @@ package bsmt
 
 import (
 	"github.com/bnb-chain/zkbnb-smt/metrics"
+	"github.com/panjf2000/ants/v2"
 )
 
 // Option is a function that configures SMT.
@@ -27,6 +28,12 @@ func BatchSizeLimit(limit int) Option {
 func DBCacheSize(size int) Option {
 	return func(smt *BASSparseMerkleTree) {
 		smt.dbCacheSize = size
+	}
+}
+
+func GoRoutinePool(pool *ants.Pool) Option {
+	return func(smt *BASSparseMerkleTree) {
+		smt.goroutinePool = pool
 	}
 }
 

--- a/smt.go
+++ b/smt.go
@@ -423,7 +423,7 @@ func (tree *BASSparseMerkleTree) Set(key uint64, val []byte) error {
 	return nil
 }
 
-func (tree *BASSparseMerkleTree) MultiSet(items ...Item) error {
+func (tree *BASSparseMerkleTree) MultiSet(items []Item) error {
 	if len(items) == 0 {
 		return nil
 	}
@@ -462,6 +462,7 @@ func (tree *BASSparseMerkleTree) MultiSet(items ...Item) error {
 		tmpJournal.set(journalKey{targetNode.depth, targetNode.path}, targetNode)
 
 		// recompute root hash of middle nodes in parallel
+		// TODO: Improved parallel computation for each depth, avoiding double computation of hashes
 		wg.Add(1)
 		func(child *TreeNode) {
 			tree.goroutinePool.Submit(func() {

--- a/smt.go
+++ b/smt.go
@@ -424,6 +424,9 @@ func (tree *BASSparseMerkleTree) Set(key uint64, val []byte) error {
 }
 
 func (tree *BASSparseMerkleTree) MultiSet(items ...Item) error {
+	if len(items) == 0 {
+		return nil
+	}
 	newVersion := tree.version + 1
 	targetNode := tree.root
 	tmpJournal := newJournal()

--- a/smt.go
+++ b/smt.go
@@ -8,6 +8,7 @@ package bsmt
 import (
 	"bytes"
 	"encoding/binary"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/rlp"
 	lru "github.com/hashicorp/golang-lru"
@@ -44,7 +45,7 @@ func NewBASSparseMerkleTree(hasher *Hasher, db database.TreeDB, maxDepth uint8, 
 
 	smt := &BASSparseMerkleTree{
 		maxDepth:       maxDepth,
-		journal:        map[journalKey]*TreeNode{},
+		journal:        newJournal(),
 		nilHashes:      constructNilHashes(maxDepth, nilHash, hasher),
 		hasher:         hasher,
 		batchSizeLimit: 100 * 1024,
@@ -109,6 +110,56 @@ func (h *nilHashes) Get(depth uint8) []byte {
 type journalKey struct {
 	depth uint8
 	path  uint64
+}
+
+func newJournal() *journal {
+	return &journal{
+		data: make(map[journalKey]*TreeNode),
+	}
+}
+
+type journal struct {
+	mu   sync.RWMutex
+	data map[journalKey]*TreeNode
+}
+
+func (j *journal) get(key journalKey) (*TreeNode, bool) {
+	j.mu.RLock()
+	defer j.mu.RUnlock()
+
+	node, exist := j.data[key]
+	return node, exist
+}
+
+func (j *journal) set(key journalKey, val *TreeNode) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.data[key] = val
+}
+
+func (j *journal) len() int {
+	j.mu.RLock()
+	defer j.mu.RUnlock()
+	return len(j.data)
+}
+
+func (j *journal) flush() {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	j.data = make(map[journalKey]*TreeNode)
+}
+
+func (j *journal) iterate(callback func(key journalKey, val *TreeNode) error) error {
+	j.mu.RLock()
+	defer j.mu.RUnlock()
+	for key, val := range j.data {
+		err := callback(key, val)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // status for GC.
@@ -179,7 +230,7 @@ type BASSparseMerkleTree struct {
 	rootSize         uint64
 	lastSaveRoot     *TreeNode
 	lastSaveRootSize uint64
-	journal          map[journalKey]*TreeNode
+	journal          *journal
 	maxDepth         uint8
 	nilHashes        *nilHashes
 	hasher           *Hasher
@@ -229,7 +280,7 @@ func (tree *BASSparseMerkleTree) initFromStorage() error {
 	}
 	tree.root = storageTreeNode.ToTreeNode(0, tree.nilHashes, tree.hasher)
 
-	tree.rootSize = tree.root.size()
+	tree.rootSize = tree.root.Size()
 	for i := 0; i < len(tree.root.Children); i++ {
 		if tree.root.Children[i] != nil {
 			tree.rootSize += uint64(versionSize * len(tree.root.Children[i].Versions))
@@ -341,7 +392,7 @@ func (tree *BASSparseMerkleTree) Set(key uint64, val []byte) error {
 	for i := 0; i < int(tree.maxDepth)/4; i++ {
 		path := key >> (int(tree.maxDepth) - (i+1)*4)
 		nibble := path & 0x000000000000000f
-		parentNodes = append(parentNodes, targetNode)
+		parentNodes = append(parentNodes, targetNode.Copy())
 		if err := tree.extendNode(targetNode, nibble, path, depth, true); err != nil {
 			return err
 		}
@@ -349,16 +400,89 @@ func (tree *BASSparseMerkleTree) Set(key uint64, val []byte) error {
 
 		depth += 4
 	}
-	targetNode = targetNode.set(val, newVersion) // leaf
-	tree.journal[journalKey{targetNode.depth, targetNode.path}] = targetNode
-	// recompute root hash
+	targetNode = targetNode.Copy()
+	targetNode.Set(val, newVersion) // update hash of leaf node
+	tree.journal.set(journalKey{targetNode.depth, targetNode.path}, targetNode)
+	// recompute root hash of middle nodes
 	for i := len(parentNodes) - 1; i >= 0; i-- {
 		childNibble := key >> (int(tree.maxDepth) - (i+1)*4) & 0x000000000000000f
-		targetNode = parentNodes[i].setChildren(targetNode, int(childNibble), newVersion)
+		parentNodes[i].SetChildren(targetNode, int(childNibble), newVersion)
 
-		tree.journal[journalKey{targetNode.depth, targetNode.path}] = targetNode
+		targetNode = parentNodes[i]
+		tree.journal.set(journalKey{targetNode.depth, targetNode.path}, targetNode)
 	}
 	tree.root = targetNode
+	return nil
+}
+
+func (tree *BASSparseMerkleTree) MultiSet(items ...Item) error {
+	newVersion := tree.version + 1
+	targetNode := tree.root
+	tmpJournal := newJournal()
+	wg := sync.WaitGroup{}
+	for _, item := range items {
+		if item.Key >= 1<<tree.maxDepth {
+			return ErrInvalidKey
+		}
+		var (
+			key         = item.Key
+			val         = item.Val
+			depth uint8 = 4
+		)
+
+		// find middle nodes
+		for i := 0; i < int(tree.maxDepth)/4; i++ {
+			path := key >> (int(tree.maxDepth) - (i+1)*4)
+			nibble := path & 0x000000000000000f
+
+			// skip the exist node
+			if _, exist := tmpJournal.get(journalKey{targetNode.depth, targetNode.path}); !exist {
+				tmpJournal.set(journalKey{targetNode.depth, targetNode.path}, targetNode.Copy())
+			}
+
+			if err := tree.extendNode(targetNode, nibble, path, depth, true); err != nil {
+				return err
+			}
+			targetNode = targetNode.Children[nibble]
+			depth += 4
+		}
+		targetNode = targetNode.Copy()
+		targetNode.Set(val, newVersion) // update hash of leaf node
+		tmpJournal.set(journalKey{targetNode.depth, targetNode.path}, targetNode)
+
+		// recompute root hash of middle nodes in parallel
+		wg.Add(1)
+		go func(child *TreeNode) {
+			defer wg.Done()
+			for child != nil {
+				parentKey := journalKey{depth: child.depth - 4, path: child.path >> 4}
+				parent, exist := tmpJournal.get(parentKey)
+				if !exist {
+					// skip if the parent is not exist
+					return
+				}
+
+				// update child to parent node
+				parent.SetChildren(child, int(child.path&0x000000000000000f), newVersion)
+				child = parent
+			}
+		}(targetNode)
+	}
+	wg.Wait()
+
+	// point root node to the new one
+	newRoot, exist := tmpJournal.get(journalKey{tree.root.depth, tree.root.path})
+	if !exist {
+		return ErrUnexpected
+	}
+	tree.root = newRoot
+
+	// flush into journal
+	tmpJournal.iterate(func(key journalKey, val *TreeNode) error {
+		tree.journal.set(key, val)
+		return nil
+	})
+
 	return nil
 }
 
@@ -484,19 +608,19 @@ func (tree *BASSparseMerkleTree) RecentVersion() Version {
 }
 
 func (tree *BASSparseMerkleTree) Reset() {
-	tree.journal = make(map[journalKey]*TreeNode)
+	tree.journal.flush()
 	tree.root = tree.lastSaveRoot
 	tree.rootSize = tree.lastSaveRootSize
 }
 
 func (tree *BASSparseMerkleTree) writeNode(db database.Batcher, fullNode *TreeNode, version Version, recentVersion *Version) (uint64, error) {
 	changed := uint64(0)
-	if fullNode.previousVersion() > tree.gcStatus.latestGCVersion {
+	if fullNode.PreviousVersion() > tree.gcStatus.latestGCVersion {
 		// If the previous version is greater than the last GC version,
 		// the node has a high probability of existing in memory
 		changed = versionSize
 	} else {
-		changed = fullNode.size()
+		changed = fullNode.Size()
 	}
 	// prune versions
 	if recentVersion != nil {
@@ -529,23 +653,27 @@ func (tree *BASSparseMerkleTree) Commit(recentVersion *Version) (Version, error)
 	}
 
 	size := uint64(0)
-	journalSize := len(tree.journal)
+	journalSize := tree.journal.len()
 	if tree.db != nil {
 		// write tree nodes, prune old version
 		batch := tree.db.NewBatch()
-		for _, node := range tree.journal {
+		err := tree.journal.iterate(func(key journalKey, node *TreeNode) error {
 			changed, err := tree.writeNode(batch, node, newVersion, recentVersion)
 			if err != nil {
-				return tree.version, err
+				return err
 			}
 			size += changed
 			if node.depth == tree.maxDepth { // leaf node
 				tree.dbCache.Add(node.path, node)
 			}
+			return nil
+		})
+		if err != nil {
+			return tree.version, err
 		}
 		buf := make([]byte, 8)
 		binary.BigEndian.PutUint64(buf, uint64(newVersion))
-		err := batch.Set(latestVersionKey, buf)
+		err = batch.Set(latestVersionKey, buf)
 		if err != nil {
 			return tree.version, err
 		}
@@ -573,10 +701,10 @@ func (tree *BASSparseMerkleTree) Commit(recentVersion *Version) (Version, error)
 	originSize := tree.rootSize
 	currentSize := tree.rootSize + size
 	if releaseVersion := tree.gcStatus.pop(currentSize); releaseVersion > 0 {
-		currentSize = tree.root.release(releaseVersion)
+		currentSize = tree.root.Release(releaseVersion)
 	}
 	tree.gcStatus.add(tree.version, currentSize)
-	tree.journal = make(map[journalKey]*TreeNode)
+	tree.journal.flush()
 	tree.lastSaveRoot = tree.root
 	tree.lastSaveRootSize = originSize
 	tree.rootSize = currentSize
@@ -619,7 +747,7 @@ func (tree *BASSparseMerkleTree) rollback(child *TreeNode, oldVersion Version, d
 			}
 			changed += subChanged
 		}
-		child.computeInternalHash()
+		child.ComputeInternalHash()
 	}
 
 	// persist tree

--- a/smt.go
+++ b/smt.go
@@ -84,7 +84,7 @@ func NewBASSparseMerkleTree(hasher *Hasher, db database.TreeDB, maxDepth uint8, 
 	}
 
 	if smt.goroutinePool == nil {
-		smt.goroutinePool, err = ants.NewPool(1024)
+		smt.goroutinePool, err = ants.NewPool(128)
 		if err != nil {
 			return nil, err
 		}

--- a/smt_test.go
+++ b/smt_test.go
@@ -8,6 +8,7 @@ package bsmt
 import (
 	"bytes"
 	"crypto/sha256"
+	"hash"
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
@@ -30,41 +31,57 @@ var (
 type testEnv struct {
 	tag    string
 	hasher *Hasher
-	db     database.TreeDB
+	db     func() (database.TreeDB, error)
 }
 
 func prepareEnv(t *testing.T) []testEnv {
-	db, err := leveldb.Open(storage.NewMemStorage(), nil)
-	if err != nil {
-		t.Fatal(err)
+	initLevelDB := func() (database.TreeDB, error) {
+		db, err := leveldb.Open(storage.NewMemStorage(), nil)
+		if err != nil {
+			return nil, err
+		}
+		return wrappedLevelDB.WrapWithNamespace(wrappedLevelDB.NewFromExistLevelDB(db), "test"), nil
 	}
-	mr, err := miniredis.Run()
-	if err != nil {
-		t.Fatal(err)
+	initRedisDB := func() (database.TreeDB, error) {
+		mr, err := miniredis.Run()
+		if err != nil {
+			return nil, err
+		}
+		client := redis.NewClient(&redis.Options{
+			Addr: mr.Addr(),
+		})
+		return wrappedRedis.WrapWithNamespace(wrappedRedis.NewFromExistRedisClient(client), "test"), nil
 	}
-	client := redis.NewClient(&redis.Options{
-		Addr: mr.Addr(),
-	})
+	initMemoryDB := func() (database.TreeDB, error) {
+		return memory.NewMemoryDB(), nil
+	}
+
 	return []testEnv{
 		{
 			tag:    "memoryDB",
-			hasher: &Hasher{sha256.New()},
-			db:     memory.NewMemoryDB(),
+			hasher: NewHasherPool(func() hash.Hash { return sha256.New() }),
+			db:     initMemoryDB,
 		},
 		{
 			tag:    "levelDB",
-			hasher: &Hasher{sha256.New()},
-			db:     wrappedLevelDB.WrapWithNamespace(wrappedLevelDB.NewFromExistLevelDB(db), "test"),
+			hasher: NewHasherPool(func() hash.Hash { return sha256.New() }),
+			db:     initLevelDB,
 		},
 		{
 			tag:    "redis",
-			hasher: &Hasher{sha256.New()},
-			db:     wrappedRedis.WrapWithNamespace(wrappedRedis.NewFromExistRedisClient(client), "test"),
+			hasher: NewHasherPool(func() hash.Hash { return sha256.New() }),
+			db:     initRedisDB,
 		},
 	}
 }
 
-func testProof(t *testing.T, hasher *Hasher, db database.TreeDB) {
+func testProof(t *testing.T, hasher *Hasher, dbInitializer func() (database.TreeDB, error)) {
+	db, err := dbInitializer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
 	smt, err := NewBASSparseMerkleTree(hasher, db, 8, nilHash)
 	if err != nil {
 		t.Fatal(err)
@@ -256,11 +273,134 @@ func Test_BASSparseMerkleTree_Proof(t *testing.T) {
 	for _, env := range prepareEnv(t) {
 		t.Logf("test [%s]", env.tag)
 		testProof(t, env.hasher, env.db)
-		env.db.Close()
 	}
 }
 
-func testRollback(t *testing.T, hasher *Hasher, db database.TreeDB) {
+func testMultiSet(t *testing.T, hasher *Hasher, dbInitializer func() (database.TreeDB, error)) {
+	db, err := dbInitializer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	smt, err := NewBASSparseMerkleTree(hasher, db, 8, nilHash,
+		GCThreshold(1024*10))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	db2, err := dbInitializer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db2.Close()
+	smt2, err := NewBASSparseMerkleTree(hasher, db2, 8, nilHash,
+		GCThreshold(1024*10))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testKVData := []Item{
+		{1, hasher.Hash([]byte("val1"))},
+		{2, hasher.Hash([]byte("val2"))},
+		{3, hasher.Hash([]byte("val3"))},
+		{4, hasher.Hash([]byte("val4"))},
+		{5, hasher.Hash([]byte("val5"))},
+		{6, hasher.Hash([]byte("val6"))},
+		{7, hasher.Hash([]byte("val7"))},
+		{8, hasher.Hash([]byte("val8"))},
+		{9, hasher.Hash([]byte("val9"))},
+		{10, hasher.Hash([]byte("val10"))},
+		{11, hasher.Hash([]byte("val11"))},
+		{12, hasher.Hash([]byte("val12"))},
+		{13, hasher.Hash([]byte("val13"))},
+		{14, hasher.Hash([]byte("val14"))},
+		{200, hasher.Hash([]byte("val200"))},
+		{20, hasher.Hash([]byte("val20"))},
+		{21, hasher.Hash([]byte("val21"))},
+		{22, hasher.Hash([]byte("val22"))},
+		{23, hasher.Hash([]byte("val23"))},
+		{24, hasher.Hash([]byte("val24"))},
+		{26, hasher.Hash([]byte("val26"))},
+		{37, hasher.Hash([]byte("val37"))},
+		{255, hasher.Hash([]byte("val255"))},
+		{254, hasher.Hash([]byte("val254"))},
+		{253, hasher.Hash([]byte("val253"))},
+		{252, hasher.Hash([]byte("val252"))},
+		{251, hasher.Hash([]byte("val251"))},
+		{250, hasher.Hash([]byte("val250"))},
+		{249, hasher.Hash([]byte("val249"))},
+		{248, hasher.Hash([]byte("val248"))},
+		{247, hasher.Hash([]byte("val247"))},
+		{15, hasher.Hash([]byte("val15"))},
+	}
+
+	t.Log("set data")
+	err = smt.MultiSet(testKVData...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = smt.Commit(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, item := range testKVData {
+		err := smt2.Set(item.Key, item.Val)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, err = smt2.Commit(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(smt.Root(), smt2.Root()) {
+		t.Fatalf("root hash does not match, %x, %x\n", smt.Root(), smt2.Root())
+	}
+
+	for _, item := range testKVData {
+		val, err := smt.Get(item.Key, nil)
+		if err != nil {
+			t.Fatal("get key from tree1 failed", item.Key, err)
+		}
+		val2, err := smt2.Get(item.Key, nil)
+		if err != nil {
+			t.Fatal("get key from tree2 failed", item.Key, err)
+		}
+		if !bytes.Equal(val, val2) {
+			t.Fatalf("leaf node does not match, %x, %x\n", val, val2)
+		}
+		if !bytes.Equal(val, item.Val) {
+			t.Fatalf("leaf node does not match the origin, %x, %x\n", val, item.Val)
+		}
+
+		proof, err := smt.GetProof(item.Key)
+		if err != nil {
+			t.Fatal("get proof from tree1 failed", item.Key, err)
+		}
+
+		if !smt2.VerifyProof(item.Key, proof) {
+			t.Fatal("verify proof from tree2 failed")
+		}
+	}
+}
+
+func Test_BASSparseMerkleTree_MultiSet(t *testing.T) {
+	for _, env := range prepareEnv(t) {
+		t.Logf("test [%s]", env.tag)
+		testMultiSet(t, env.hasher, env.db)
+	}
+}
+
+func testRollback(t *testing.T, hasher *Hasher, dbInitializer func() (database.TreeDB, error)) {
+	db, err := dbInitializer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
 	smt, err := NewBASSparseMerkleTree(hasher, db, 8, nilHash)
 	if err != nil {
 		t.Fatal(err)
@@ -342,14 +482,22 @@ func Test_BASSparseMerkleTree_Rollback(t *testing.T) {
 	for _, env := range prepareEnv(t) {
 		t.Logf("test [%s]", env.tag)
 		testRollback(t, env.hasher, env.db)
-		env.db.Close()
 	}
 }
 
-func testRollbackRecovery(t *testing.T, hasher *Hasher, db database.TreeDB) {
-	db1 := memory.NewMemoryDB()
-	db2 := memory.NewMemoryDB()
-	smt, err := NewBASSparseMerkleTree(hasher, db1, 8, nilHash)
+func testRollbackRecovery(t *testing.T, hasher *Hasher, dbInitializer func() (database.TreeDB, error)) {
+	db, err := dbInitializer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	db2, err := dbInitializer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db2.Close()
+
+	smt, err := NewBASSparseMerkleTree(hasher, db, 8, nilHash)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -445,11 +593,16 @@ func Test_BASSparseMerkleTree_RollbackAfterRecovery(t *testing.T) {
 	for _, env := range prepareEnv(t) {
 		t.Logf("test [%s]", env.tag)
 		testRollbackRecovery(t, env.hasher, env.db)
-		env.db.Close()
 	}
 }
 
-func testReset(t *testing.T, hasher *Hasher, db database.TreeDB) {
+func testReset(t *testing.T, hasher *Hasher, dbInitializer func() (database.TreeDB, error)) {
+	db, err := dbInitializer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
 	smt, err := NewBASSparseMerkleTree(hasher, db, 8, nilHash)
 	if err != nil {
 		t.Fatal(err)
@@ -487,11 +640,16 @@ func Test_BASSparseMerkleTree_Reset(t *testing.T) {
 	for _, env := range prepareEnv(t) {
 		t.Logf("test [%s]", env.tag)
 		testReset(t, env.hasher, env.db)
-		env.db.Close()
 	}
 }
 
-func testGC(t *testing.T, hasher *Hasher, db database.TreeDB) {
+func testGC(t *testing.T, hasher *Hasher, dbInitializer func() (database.TreeDB, error)) {
+	db, err := dbInitializer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
 	smt, err := NewBASSparseMerkleTree(hasher, db, 8, nilHash,
 		GCThreshold(1024*10))
 	if err != nil {
@@ -596,6 +754,5 @@ func Test_BASSparseMerkleTree_GC(t *testing.T) {
 	for _, env := range prepareEnv(t) {
 		t.Logf("test [%s]", env.tag)
 		testGC(t, env.hasher, env.db)
-		env.db.Close()
 	}
 }

--- a/smt_test.go
+++ b/smt_test.go
@@ -335,7 +335,7 @@ func testMultiSet(t *testing.T, hasher *Hasher, dbInitializer func() (database.T
 	}
 
 	t.Log("set data")
-	err = smt.MultiSet(testKVData...)
+	err = smt.MultiSet(testKVData)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tree_node_test.go
+++ b/tree_node_test.go
@@ -8,11 +8,14 @@ package bsmt
 import (
 	"bytes"
 	"crypto/sha256"
+	"hash"
 	"testing"
 )
 
 func TestTreeNode_Copy(t *testing.T) {
-	hasher := &Hasher{sha256.New()}
+	hasher := NewHasherPool(func() hash.Hash {
+		return sha256.New()
+	})
 	nilHashes := &nilHashes{[][]byte{
 		[]byte("test0"),
 		[]byte("test1"),
@@ -23,10 +26,10 @@ func TestTreeNode_Copy(t *testing.T) {
 	node := NewTreeNode(0, 0, nilHashes, hasher)
 	copied := node.Copy()
 	for i := 0; i < len(copied.Children); i++ {
-		copied = copied.setChildren(NewTreeNode(4, uint64(i), nilHashes, hasher), i, 0)
+		copied.SetChildren(NewTreeNode(4, uint64(i), nilHashes, hasher), i, 0)
 	}
-	copied.computeInternalHash()
-	copied = copied.set(hasher.Hash(copied.Internals[0], copied.Internals[1]), 0)
+	copied.ComputeInternalHash()
+	copied.Set(hasher.Hash(copied.Internals[0], copied.Internals[1]), 0)
 
 	if bytes.Equal(node.Root(), copied.Root()) {
 		t.Fatal("root should not be equal")


### PR DESCRIPTION
### Description

Implement the `MultiSet` method and calculate root hash in parallel.

### Rationale

Write to multiple leaf nodes in parallel and calculate Hash upwards at the same time

### Example

```go
testKVData := []Item{
	{1, hasher.Hash([]byte("val1"))},
	{2, hasher.Hash([]byte("val2"))},
	{3, hasher.Hash([]byte("val3"))},
	{4, hasher.Hash([]byte("val4"))},
	{5, hasher.Hash([]byte("val5"))},
	{6, hasher.Hash([]byte("val6"))},
	{7, hasher.Hash([]byte("val7"))},
	{8, hasher.Hash([]byte("val8"))},
	{9, hasher.Hash([]byte("val9"))},
	{10, hasher.Hash([]byte("val10"))},
	{11, hasher.Hash([]byte("val11"))},
	{12, hasher.Hash([]byte("val12"))},
	{13, hasher.Hash([]byte("val13"))},
	{14, hasher.Hash([]byte("val14"))},
	{200, hasher.Hash([]byte("val200"))},
	{20, hasher.Hash([]byte("val20"))},
	{21, hasher.Hash([]byte("val21"))},
	{22, hasher.Hash([]byte("val22"))},
	{23, hasher.Hash([]byte("val23"))},
	{24, hasher.Hash([]byte("val24"))},
	{26, hasher.Hash([]byte("val26"))},
	{37, hasher.Hash([]byte("val37"))},
	{255, hasher.Hash([]byte("val255"))},
	{254, hasher.Hash([]byte("val254"))},
	{253, hasher.Hash([]byte("val253"))},
	{252, hasher.Hash([]byte("val252"))},
	{251, hasher.Hash([]byte("val251"))},
	{250, hasher.Hash([]byte("val250"))},
	{249, hasher.Hash([]byte("val249"))},
	{248, hasher.Hash([]byte("val248"))},
	{247, hasher.Hash([]byte("val247"))},
	{15, hasher.Hash([]byte("val15"))},
}

err = smt.MultiSet(testKVData...)
if err != nil {
	t.Fatal(err)
}
```

### Changes

Notable changes:
* implement MultiSet method