### PR TITLE
Rebrand BASSparseMerkleTree to BNBSparseMerkleTree

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ func main() {
 	nilHash := hasher.Hash([]byte("nilHash"))
 	maxDepth := uint8(8)
 
-	smt, err := bsmt.NewBASSparseMerkleTree(hasher, db, maxDepth, nilHash)
+	smt, err := bsmt.NewBNBSparseMerkleTree(hasher, db, maxDepth, nilHash)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/options.go
+++ b/options.go
@@ -11,34 +11,34 @@ import (
 )
 
 // Option is a function that configures SMT.
-type Option func(*BASSparseMerkleTree)
+type Option func(*BNBSparseMerkleTree)
 
 func InitializeVersion(version Version) Option {
-	return func(smt *BASSparseMerkleTree) {
+	return func(smt *BNBSparseMerkleTree) {
 		smt.version = version
 	}
 }
 
 func BatchSizeLimit(limit int) Option {
-	return func(smt *BASSparseMerkleTree) {
+	return func(smt *BNBSparseMerkleTree) {
 		smt.batchSizeLimit = limit
 	}
 }
 
 func DBCacheSize(size int) Option {
-	return func(smt *BASSparseMerkleTree) {
+	return func(smt *BNBSparseMerkleTree) {
 		smt.dbCacheSize = size
 	}
 }
 
 func GoRoutinePool(pool *ants.Pool) Option {
-	return func(smt *BASSparseMerkleTree) {
+	return func(smt *BNBSparseMerkleTree) {
 		smt.goroutinePool = pool
 	}
 }
 
 func GCThreshold(threshold uint64) Option {
-	return func(smt *BASSparseMerkleTree) {
+	return func(smt *BNBSparseMerkleTree) {
 		if smt.gcStatus != nil {
 			smt.gcStatus.threshold = threshold
 			smt.gcStatus.segment = threshold / 10
@@ -48,7 +48,7 @@ func GCThreshold(threshold uint64) Option {
 }
 
 func EnableMetrics(metrics metrics.Metrics) Option {
-	return func(smt *BASSparseMerkleTree) {
+	return func(smt *BNBSparseMerkleTree) {
 		smt.metrics = metrics
 	}
 }

--- a/smt.go
+++ b/smt.go
@@ -36,14 +36,14 @@ func storageFullTreeNodeKey(depth uint8, path uint64) []byte {
 	return bytes.Join([][]byte{storageFullTreeNodePrefix, {depth}, pathBuf}, sep)
 }
 
-var _ SparseMerkleTree = (*BASSparseMerkleTree)(nil)
+var _ SparseMerkleTree = (*BNBSparseMerkleTree)(nil)
 
 func NewSparseMerkleTree(hasher *Hasher, db database.TreeDB, maxDepth uint8, hashes [][]byte, opts ...Option) (SparseMerkleTree, error) {
 	if maxDepth == 0 || maxDepth%4 != 0 {
 		return nil, ErrInvalidDepth
 	}
 
-	smt := &BASSparseMerkleTree{
+	smt := &BNBSparseMerkleTree{
 		maxDepth:       maxDepth,
 		journal:        newJournal(),
 		nilHashes:      &nilHashes{hashes},
@@ -92,14 +92,14 @@ func NewSparseMerkleTree(hasher *Hasher, db database.TreeDB, maxDepth uint8, has
 	return smt, nil
 }
 
-func NewBASSparseMerkleTree(hasher *Hasher, db database.TreeDB, maxDepth uint8, nilHash []byte,
+func NewBNBSparseMerkleTree(hasher *Hasher, db database.TreeDB, maxDepth uint8, nilHash []byte,
 	opts ...Option) (SparseMerkleTree, error) {
 
 	if maxDepth == 0 || maxDepth%4 != 0 {
 		return nil, ErrInvalidDepth
 	}
 
-	smt := &BASSparseMerkleTree{
+	smt := &BNBSparseMerkleTree{
 		maxDepth:       maxDepth,
 		journal:        newJournal(),
 		nilHashes:      constructNilHashes(maxDepth, nilHash, hasher),
@@ -302,7 +302,7 @@ func (stat *gcStatus) clean(index int) {
 	}
 }
 
-type BASSparseMerkleTree struct {
+type BNBSparseMerkleTree struct {
 	version          Version
 	recentVersion    Version
 	root             *TreeNode
@@ -322,7 +322,7 @@ type BASSparseMerkleTree struct {
 	metrics          metrics.Metrics
 }
 
-func (tree *BASSparseMerkleTree) initFromStorage() error {
+func (tree *BNBSparseMerkleTree) initFromStorage() error {
 	tree.root = NewTreeNode(0, 0, tree.nilHashes, tree.hasher)
 	// recovery version info
 	buf, err := tree.db.Get(latestVersionKey)
@@ -369,7 +369,7 @@ func (tree *BASSparseMerkleTree) initFromStorage() error {
 	return nil
 }
 
-func (tree *BASSparseMerkleTree) extendNode(node *TreeNode, nibble, path uint64, depth uint8, isCreated bool) error {
+func (tree *BNBSparseMerkleTree) extendNode(node *TreeNode, nibble, path uint64, depth uint8, isCreated bool) error {
 	if node.Children[nibble] != nil &&
 		!node.Children[nibble].IsTemporary() {
 		return nil
@@ -397,11 +397,11 @@ func (tree *BASSparseMerkleTree) extendNode(node *TreeNode, nibble, path uint64,
 	return nil
 }
 
-func (tree *BASSparseMerkleTree) Size() uint64 {
+func (tree *BNBSparseMerkleTree) Size() uint64 {
 	return tree.rootSize
 }
 
-func (tree *BASSparseMerkleTree) Get(key uint64, version *Version) ([]byte, error) {
+func (tree *BNBSparseMerkleTree) Get(key uint64, version *Version) ([]byte, error) {
 	if tree.IsEmpty() {
 		return nil, ErrEmptyRoot
 	}
@@ -459,7 +459,7 @@ func (tree *BASSparseMerkleTree) Get(key uint64, version *Version) ([]byte, erro
 	return tree.nilHashes.Get(tree.maxDepth), nil
 }
 
-func (tree *BASSparseMerkleTree) Set(key uint64, val []byte) error {
+func (tree *BNBSparseMerkleTree) Set(key uint64, val []byte) error {
 	if key >= 1<<tree.maxDepth {
 		return ErrInvalidKey
 	}
@@ -501,7 +501,7 @@ func (tree *BASSparseMerkleTree) Set(key uint64, val []byte) error {
 // 1. generate all intermediate nodes, with lock;
 // 2. set all leaves, without lock;
 // 3. re-compute hash, from leaves to root
-func (tree *BASSparseMerkleTree) MultiSet(items []Item) error {
+func (tree *BNBSparseMerkleTree) MultiSet(items []Item) error {
 	size := len(items)
 	if size == 0 {
 		return nil
@@ -575,7 +575,7 @@ func (tree *BASSparseMerkleTree) MultiSet(items []Item) error {
 }
 
 // return leaf node
-func (tree *BASSparseMerkleTree) setIntermediateAndLeaves(tmpJournal *journal, item Item) (*TreeNode, error) {
+func (tree *BNBSparseMerkleTree) setIntermediateAndLeaves(tmpJournal *journal, item Item) (*TreeNode, error) {
 	var (
 		key         = item.Key
 		val         = item.Val
@@ -612,15 +612,15 @@ func (tree *BASSparseMerkleTree) setIntermediateAndLeaves(tmpJournal *journal, i
 	return targetNode, nil
 }
 
-func (tree *BASSparseMerkleTree) IsEmpty() bool {
+func (tree *BNBSparseMerkleTree) IsEmpty() bool {
 	return bytes.Equal(tree.root.Root(), tree.nilHashes.Get(0))
 }
 
-func (tree *BASSparseMerkleTree) Root() []byte {
+func (tree *BNBSparseMerkleTree) Root() []byte {
 	return tree.root.Root()
 }
 
-func (tree *BASSparseMerkleTree) GetProof(key uint64) (Proof, error) {
+func (tree *BNBSparseMerkleTree) GetProof(key uint64) (Proof, error) {
 	proofs := make([][]byte, 0, tree.maxDepth/4)
 	if tree.IsEmpty() {
 		for i := tree.maxDepth; i > 0; i-- {
@@ -667,7 +667,7 @@ func (tree *BASSparseMerkleTree) GetProof(key uint64) (Proof, error) {
 	return utils.ReverseBytes(proofs[:]), nil
 }
 
-func (tree *BASSparseMerkleTree) VerifyProof(key uint64, proof Proof) bool {
+func (tree *BNBSparseMerkleTree) VerifyProof(key uint64, proof Proof) bool {
 	if key >= 1<<tree.maxDepth {
 		return false
 	}
@@ -725,21 +725,21 @@ func (tree *BASSparseMerkleTree) VerifyProof(key uint64, proof Proof) bool {
 	return bytes.Equal(root, node)
 }
 
-func (tree *BASSparseMerkleTree) LatestVersion() Version {
+func (tree *BNBSparseMerkleTree) LatestVersion() Version {
 	return tree.version
 }
 
-func (tree *BASSparseMerkleTree) RecentVersion() Version {
+func (tree *BNBSparseMerkleTree) RecentVersion() Version {
 	return tree.recentVersion
 }
 
-func (tree *BASSparseMerkleTree) Reset() {
+func (tree *BNBSparseMerkleTree) Reset() {
 	tree.journal.flush()
 	tree.root = tree.lastSaveRoot
 	tree.rootSize = tree.lastSaveRootSize
 }
 
-func (tree *BASSparseMerkleTree) writeNode(db database.Batcher, fullNode *TreeNode, version Version, recentVersion *Version) (uint64, error) {
+func (tree *BNBSparseMerkleTree) writeNode(db database.Batcher, fullNode *TreeNode, version Version, recentVersion *Version) (uint64, error) {
 	changed := uint64(0)
 	if fullNode.PreviousVersion() > tree.gcStatus.latestGCVersion {
 		// If the previous version is greater than the last GC version,
@@ -772,7 +772,7 @@ func (tree *BASSparseMerkleTree) writeNode(db database.Batcher, fullNode *TreeNo
 	return changed, nil
 }
 
-func (tree *BASSparseMerkleTree) Commit(recentVersion *Version) (Version, error) {
+func (tree *BNBSparseMerkleTree) Commit(recentVersion *Version) (Version, error) {
 	newVersion := tree.version + 1
 	if recentVersion != nil && *recentVersion >= newVersion {
 		return tree.version, ErrVersionTooHigh
@@ -847,7 +847,7 @@ func (tree *BASSparseMerkleTree) Commit(recentVersion *Version) (Version, error)
 	return newVersion, nil
 }
 
-func (tree *BASSparseMerkleTree) rollback(child *TreeNode, oldVersion Version, db database.Batcher) (uint64, error) {
+func (tree *BNBSparseMerkleTree) rollback(child *TreeNode, oldVersion Version, db database.Batcher) (uint64, error) {
 	// remove value nodes
 	next, changed := child.Rollback(oldVersion)
 	if !next {
@@ -895,7 +895,7 @@ func (tree *BASSparseMerkleTree) rollback(child *TreeNode, oldVersion Version, d
 	return changed, nil
 }
 
-func (tree *BASSparseMerkleTree) Rollback(version Version) error {
+func (tree *BNBSparseMerkleTree) Rollback(version Version) error {
 	if tree.IsEmpty() {
 		return ErrEmptyRoot
 	}
@@ -946,7 +946,7 @@ func (tree *BASSparseMerkleTree) Rollback(version Version) error {
 	return nil
 }
 
-func (tree *BASSparseMerkleTree) collectGCMetrics() {
+func (tree *BNBSparseMerkleTree) collectGCMetrics() {
 	tree.metrics.LatestGCVersion(uint64(tree.gcStatus.latestGCVersion))
 	var gcVersions [10]*metrics.GCVersion
 	for i := range tree.gcStatus.versions {
@@ -958,7 +958,7 @@ func (tree *BASSparseMerkleTree) collectGCMetrics() {
 	tree.metrics.GCVersions(gcVersions)
 }
 
-func (tree *BASSparseMerkleTree) recompute(node *TreeNode, journals *journal) {
+func (tree *BNBSparseMerkleTree) recompute(node *TreeNode, journals *journal) {
 	version := node.latestVersion()
 	child := node
 	for child != nil {

--- a/smt_test.go
+++ b/smt_test.go
@@ -83,7 +83,7 @@ func testProof(t *testing.T, hasher *Hasher, dbInitializer func() (database.Tree
 	}
 	defer db.Close()
 
-	smt, err := NewBASSparseMerkleTree(hasher, db, 8, nilHash)
+	smt, err := NewBNBSparseMerkleTree(hasher, db, 8, nilHash)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -193,7 +193,7 @@ func testProof(t *testing.T, hasher *Hasher, dbInitializer func() (database.Tree
 	}
 
 	// restore tree from db
-	smt2, err := NewBASSparseMerkleTree(hasher, db, 8, nilHash)
+	smt2, err := NewBNBSparseMerkleTree(hasher, db, 8, nilHash)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -270,7 +270,7 @@ func testProof(t *testing.T, hasher *Hasher, dbInitializer func() (database.Tree
 	}
 }
 
-func Test_BASSparseMerkleTree_Proof(t *testing.T) {
+func Test_BNBSparseMerkleTree_Proof(t *testing.T) {
 	for _, env := range prepareEnv() {
 		t.Logf("test [%s]", env.tag)
 		testProof(t, env.hasher, env.db)
@@ -284,7 +284,7 @@ func testRollback(t *testing.T, hasher *Hasher, dbInitializer func() (database.T
 	}
 	defer db.Close()
 
-	smt, err := NewBASSparseMerkleTree(hasher, db, 8, nilHash)
+	smt, err := NewBNBSparseMerkleTree(hasher, db, 8, nilHash)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -347,7 +347,7 @@ func testRollback(t *testing.T, hasher *Hasher, dbInitializer func() (database.T
 	}
 
 	// restore tree from db
-	smt2, err := NewBASSparseMerkleTree(hasher, db, 8, nilHash)
+	smt2, err := NewBNBSparseMerkleTree(hasher, db, 8, nilHash)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -361,7 +361,7 @@ func testRollback(t *testing.T, hasher *Hasher, dbInitializer func() (database.T
 	}
 }
 
-func Test_BASSparseMerkleTree_Rollback(t *testing.T) {
+func Test_BNBSparseMerkleTree_Rollback(t *testing.T) {
 	for _, env := range prepareEnv() {
 		t.Logf("test [%s]", env.tag)
 		testRollback(t, env.hasher, env.db)
@@ -380,11 +380,11 @@ func testRollbackRecovery(t *testing.T, hasher *Hasher, dbInitializer func() (da
 	}
 	defer db2.Close()
 
-	smt, err := NewBASSparseMerkleTree(hasher, db, 8, nilHash)
+	smt, err := NewBNBSparseMerkleTree(hasher, db, 8, nilHash)
 	if err != nil {
 		t.Fatal(err)
 	}
-	smt2, err := NewBASSparseMerkleTree(hasher, db2, 8, nilHash)
+	smt2, err := NewBNBSparseMerkleTree(hasher, db2, 8, nilHash)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -440,7 +440,7 @@ func testRollbackRecovery(t *testing.T, hasher *Hasher, dbInitializer func() (da
 	}
 
 	// restore tree from db
-	smt2, err = NewBASSparseMerkleTree(hasher, db2, 8, nilHash)
+	smt2, err = NewBNBSparseMerkleTree(hasher, db2, 8, nilHash)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -472,7 +472,7 @@ func testRollbackRecovery(t *testing.T, hasher *Hasher, dbInitializer func() (da
 	}
 }
 
-func Test_BASSparseMerkleTree_RollbackAfterRecovery(t *testing.T) {
+func Test_BNBSparseMerkleTree_RollbackAfterRecovery(t *testing.T) {
 	for _, env := range prepareEnv() {
 		t.Logf("test [%s]", env.tag)
 		testRollbackRecovery(t, env.hasher, env.db)
@@ -486,7 +486,7 @@ func testReset(t *testing.T, hasher *Hasher, dbInitializer func() (database.Tree
 	}
 	defer db.Close()
 
-	smt, err := NewBASSparseMerkleTree(hasher, db, 8, nilHash)
+	smt, err := NewBNBSparseMerkleTree(hasher, db, 8, nilHash)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -519,7 +519,7 @@ func testReset(t *testing.T, hasher *Hasher, dbInitializer func() (database.Tree
 	smt.Reset()
 }
 
-func Test_BASSparseMerkleTree_Reset(t *testing.T) {
+func Test_BNBSparseMerkleTree_Reset(t *testing.T) {
 	for _, env := range prepareEnv() {
 		t.Logf("test [%s]", env.tag)
 		testReset(t, env.hasher, env.db)
@@ -533,7 +533,7 @@ func testGC(t *testing.T, hasher *Hasher, dbInitializer func() (database.TreeDB,
 	}
 	defer db.Close()
 
-	smt, err := NewBASSparseMerkleTree(hasher, db, 8, nilHash,
+	smt, err := NewBNBSparseMerkleTree(hasher, db, 8, nilHash,
 		GCThreshold(1024*10))
 	if err != nil {
 		t.Fatal(err)
@@ -597,14 +597,14 @@ func testGC(t *testing.T, hasher *Hasher, dbInitializer func() (database.TreeDB,
 	}
 }
 
-func Test_BASSparseMerkleTree_GC(t *testing.T) {
+func Test_BNBSparseMerkleTree_GC(t *testing.T) {
 	for _, env := range prepareEnv() {
 		t.Logf("test [%s]", env.tag)
 		testGC(t, env.hasher, env.db)
 	}
 }
 
-func Test_BASSparseMerkleTree_MultiSet(t *testing.T) {
+func Test_BNBSparseMerkleTree_MultiSet(t *testing.T) {
 	rawKvs := map[uint64]string{
 		1:   "val1",
 		2:   "val2",
@@ -725,7 +725,7 @@ func Test_SingleMultiSet(t *testing.T) {
 	testMultiSet(t, memEnv, items, 8)
 }
 
-func Test_BASSparseMerkleTree_Set(t *testing.T) {
+func Test_BNBSparseMerkleTree_Set(t *testing.T) {
 	for _, env := range prepareEnv() {
 		t.Logf("test [%s]", env.tag)
 		testSet(t, env, 8)
@@ -780,7 +780,7 @@ func testMultiSet(t *testing.T, env testEnv, items []Item, depth uint8) (time.Du
 }
 
 func newSMT(t *testing.T, hasher *Hasher, db database.TreeDB, maxDepth uint8) SparseMerkleTree {
-	smt, err := NewBASSparseMerkleTree(hasher, db, maxDepth, nilHash,
+	smt, err := NewBNBSparseMerkleTree(hasher, db, maxDepth, nilHash,
 		GCThreshold(1024*10))
 	if err != nil {
 		t.Fatal(err)
@@ -867,7 +867,7 @@ func benchmarkSet(b *testing.B, env testEnv, depth uint8, items []Item) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	smt, err := NewBASSparseMerkleTree(env.hasher, db, depth, nilHash,
+	smt, err := NewBNBSparseMerkleTree(env.hasher, db, depth, nilHash,
 		GCThreshold(1024*10))
 	if err != nil {
 		b.Fatal(err)
@@ -900,7 +900,7 @@ func benchmarkMultiset(b *testing.B, env testEnv, depth uint8, items []Item) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	smt, err := NewBASSparseMerkleTree(env.hasher, db, depth, nilHash,
+	smt, err := NewBNBSparseMerkleTree(env.hasher, db, depth, nilHash,
 		GCThreshold(1024*10))
 	if err != nil {
 		b.Fatal(err)


### PR DESCRIPTION
### Description

Change struct name from BASSparseMerkleTree to BNBSparseMerkleTree.
This PR should be merged after #8 being merged.

### Rationale

BASSparseMerkleTree doesn't make sense any more.
After this merge, we should change the name in zkBNB, too. Another PR will be sent later.

### Example


### Changes

Only name changes