### PR TITLE
Fix GitHub workflow

### DIFF
--- a/.github/workflows/checker.yml
+++ b/.github/workflows/checker.yml
@@ -3,11 +3,11 @@ name: Checker
 on:
   push:
     branches:
-      - main
-      
+      - master
+
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   test:
@@ -18,12 +18,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
-        
+
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Test
       run: go test ./...

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## zkbnb-smt
 
 <p>
-  <img src="https://img.shields.io/github/workflow/status/bnb-chain/zkbnb-smt/Checker?style=flat-square">
+  <img src="https://img.shields.io/github/actions/workflow/status/bnb-chain/zkbnb-smt/checker.yml?style=flat-square">
   <a href="https://github.com/bnb-chain/zkbnb-smt/blob/master/LICENSE">
     <img src="https://img.shields.io/github/license/globocom/go-buffer?color=blue&style=flat-square">
   </a>


### PR DESCRIPTION
### Description

Fix GitHub workflow badge routes due to [8671](https://github.com/badges/shields/issues/8671)

Fix GitHub workflow 

### Rationale

The key change here is that the workflow parameter is now the workflow filename, not the name: defined in yaml
Exist workflow defined a wrong trigger branch.

### Example


### Changes

* trigger branch set to master
* fix badge
