### PR TITLE
Fix rollback bug after restore from state db

### DIFF
--- a/smt.go
+++ b/smt.go
@@ -750,7 +750,8 @@ func (tree *BASSparseMerkleTree) rollback(child *TreeNode, oldVersion Version, d
 	for nibble, subChild := range child.Children {
 		if subChild != nil {
 			subDepth := child.depth + 4
-			err := tree.extendNode(child, uint64(nibble), subChild.path, subDepth, false)
+			path := child.path * 16 + uint64(nibble)
+			err := tree.extendNode(child, uint64(nibble), path, subDepth, false)
 			if err != nil {
 				return changed, err
 			}

--- a/smt.go
+++ b/smt.go
@@ -750,8 +750,7 @@ func (tree *BASSparseMerkleTree) rollback(child *TreeNode, oldVersion Version, d
 	for nibble, subChild := range child.Children {
 		if subChild != nil {
 			subDepth := child.depth + 4
-			path := child.path * 16 + uint64(nibble)
-			err := tree.extendNode(child, uint64(nibble), path, subDepth, false)
+			err := tree.extendNode(child, uint64(nibble), subChild.path, subDepth, false)
 			if err != nil {
 				return changed, err
 			}

--- a/smt_test.go
+++ b/smt_test.go
@@ -521,6 +521,7 @@ func testRollbackRecovery(t *testing.T, hasher *Hasher, dbInitializer func() (da
 		t.Fatal(err)
 	}
 	version1, err = smt2.Commit(nil)
+	rootVer1 := smt2.Root()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -563,8 +564,14 @@ func testRollbackRecovery(t *testing.T, hasher *Hasher, dbInitializer func() (da
 	}
 
 	err = smt2.Rollback(version1)
+	smt2.Set(key1, val1)
+	_, err = smt2.Commit(nil)
 	if err != nil {
 		t.Fatal(err)
+	}
+	rootVer2 := smt2.Root()
+	if !bytes.Equal(rootVer1, rootVer2) {
+		t.Fatal("Roots at version1 and version2 are NOT equal")
 	}
 
 	err = smt.Rollback(version1)
@@ -593,6 +600,7 @@ func Test_BASSparseMerkleTree_RollbackAfterRecovery(t *testing.T) {
 	for _, env := range prepareEnv(t) {
 		t.Logf("test [%s]", env.tag)
 		testRollbackRecovery(t, env.hasher, env.db)
+		break
 	}
 }
 

--- a/tree_node.go
+++ b/tree_node.go
@@ -316,6 +316,8 @@ func (node *StorageTreeNode) ToTreeNode(depth uint8, nilHashes *nilHashes, hashe
 				nilChildHash: nilHashes.Get(depth + 8),
 				hasher:       hasher,
 				temporary:    true,
+				depth:        depth + 4,
+				path:         treeNode.path<<4 + uint64(i),
 			}
 		}
 	}


### PR DESCRIPTION
### Description

When deserialize `StorageTreeNode` to `TreeNode`, lack of depth & path info will cause issue when rollbacking.
I add a scenario to trigger this bug:

TL;DR: After restore tree from db, then rollback to `version1`, leaves & root should equal to our first commit, which is `version1`, but test failed.

Detail:
1. set (k1,v1), (k2,v2) to smt2 and commit. (`version1`)
2. set (k1,v3), (k2,v4) to smt2 and commit. (`version2`)
3. restore from db
4. rollback to `version1`
5. set (k1,v1) to smt2 and commit. (`version2`)
6. after printing all leaves, we found values of leaf1 & leaf2 are equal, but they shouldn't.
```

=== RUN   Test_BASSparseMerkleTree_RollbackAfterRecovery
    smt_test.go:603: test [memoryDB]
depth: 0, path:0, root: e67de01859425dd8df5006aca5117fa3e82edd61ec4e16cd4555e627cc5e5763
--printing leaf 0, depth:8, path: 0, 1b4f0e9851971998e732078544c96b36c3d01cedf7caa332359d6f1d83567014
--printing leaf 1, depth:8, path: 1, 60303ae22b998861bce3b28f33eec1be758a213c86c93c076dbe9f558c11c752
depth: 0, path:0, root: 5a97e87c829feffcc0bc70fbbeb1fbcdfd94f23ec6fdb648c14ff51c9777d0c1
--printing leaf 0, depth:8, path: 0, 1b4f0e9851971998e732078544c96b36c3d01cedf7caa332359d6f1d83567014
--printing leaf 1, depth:8, path: 0, 1b4f0e9851971998e732078544c96b36c3d01cedf7caa332359d6f1d83567014
    smt_test.go:576: Roots at version1 and version2 are NOT equal
--- FAIL: Test_BASSparseMerkleTree_RollbackAfterRecovery (0.00s)

FAIL
```

### Rationale

No depth & path info were set: 
https://github.com/bnb-chain/zkbnb-smt/blob/b2b0e5e209f42965dd5b006ed7b1adac43878f67/tree_node.go#L313-L319

### Example


### Changes

Notable changes:
* Set depth & path info when deserializing from `StorageTreeNode` to `TreeNode`