### PR TITLE
Add feature query version from root hash.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -27,4 +27,6 @@ var (
 	ErrInvalidDepth = errors.New("depth must be a multiple of 4")
 
 	ErrExtendNode = errors.New("extending node error")
+
+	ErrVersionNotFound = errors.New("version not found")
 )

--- a/interface.go
+++ b/interface.go
@@ -26,5 +26,6 @@ type (
 		Reset()
 		Commit(recentVersion *Version) (Version, error)
 		Rollback(version Version) error
+		QueryVersion(rootHash []byte) (Version, error)
 	}
 )

--- a/smt.go
+++ b/smt.go
@@ -978,3 +978,7 @@ func (tree *BNBSparseMerkleTree) recompute(node *TreeNode, journals *journal) {
 		}
 	}
 }
+
+func (tree *BNBSparseMerkleTree) QueryVersion(rootHash []byte) (Version, error) {
+	return tree.root.QueryVersion(rootHash)
+}

--- a/tree_node.go
+++ b/tree_node.go
@@ -6,6 +6,7 @@
 package bsmt
 
 import (
+	"bytes"
 	"sync"
 )
 
@@ -64,6 +65,18 @@ func (node *TreeNode) Root() []byte {
 		return node.nilHash
 	}
 	return node.Versions[len(node.Versions)-1].Hash
+}
+
+func (node *TreeNode) QueryVersion(rootHash []byte) (Version, error) {
+	node.mu.RLock()
+	defer node.mu.RUnlock()
+
+	for _, v := range node.Versions {
+		if bytes.Equal(rootHash, v.Hash) {
+			return v.Ver, nil
+		}
+	}
+	return Version(0), ErrVersionNotFound
 }
 
 // Root Get latest hash of a node without a lock


### PR DESCRIPTION
### Description

Add feature to query version from state root, can be used in rollback scenario.

Version of account tree equals to block height, but it's not the case for the asset tree, in order to rollback asset tree as well, we need to know the exact version that we want to rollback to.

### Rationale

We can achieve that by querying version from root node.

### Example
```
actualVer1, err := smt.QueryVersion(root1)
```

### Changes

Notable changes:
* add an interface `QueryVersion(rootHash []byte) (Version, error)`
