### PR TITLE
Add a release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Release
+        uses: softprops/action-gh-release@v1


### PR DESCRIPTION
### Description

add a release workflow

### Rationale

automate the release process, will publish a release when pushing a tag

### Example

[v0.0.5](https://github.com/qct/zkbnb-smt/releases/tag/v0.0.5)

### Changes

Notable changes:
