### PR TITLE
Fix ErrEmptyRoot when rollback from empty tree(actually not)

### DIFF
--- a/smt.go
+++ b/smt.go
@@ -932,10 +932,6 @@ func (tree *BNBSparseMerkleTree) rollback(child *TreeNode, oldVersion Version, d
 }
 
 func (tree *BNBSparseMerkleTree) Rollback(version Version) error {
-	if tree.IsEmpty() {
-		return ErrEmptyRoot
-	}
-
 	if tree.recentVersion > version {
 		return ErrVersionTooOld
 	}


### PR DESCRIPTION
### Description

Fix rollback issue when a tree step into initial state.

### Rationale

Because the function `tree.IsEmpty` is by testing if tree's root equals to nil hash at depth 0 like below:
```
return bytes.Equal(tree.root.Root(), tree.nilHashes.Get(0))
```
which means if a tree step into initial state in the future, this function will return true.   

Let's say initial root is A, after setting to a leaf, root changed to B, then set that leaf to nil hash, root will change to A again,
that will cause problem when rolling back, because there're versions inside this tree, but can't be rolled back.

### Example
```
smt1 := newSMT(t, env.hasher, db1, depth)
fmt.Printf("initial root hash: %x\n", smt1.Root())

smt1.Set(items[0].Key, items[0].Val)
_, err = smt1.Commit(nil)
fmt.Printf("root hash after set value: %x\n", smt1.Root())

smt1.Set(items[0].Key, nilHash)
_, err = smt1.Commit(nil)
fmt.Printf("root hash after setting to nil hash: %x\n", smt1.Root())
fmt.Println("is empty: ", smt1.IsEmpty())
```

Output:
```
initial root hash: 4a84586a612ce66d63bf29d3ddad5a610f641530613630ecbd67ec23a91c4c56
root hash after set value: b21cc61fe181e31645759e5f56836248e433978165f63d1b712e86b3c63fe54e
root hash after setting to nil hash: 4a84586a612ce66d63bf29d3ddad5a610f641530613630ecbd67ec23a91c4c56
is empty:  true
```


### Changes

* Remove `tree.IsEmpty` check in `tree.Rollback`