### PR TITLE
Add a switch to make the smt key as readable

### DIFF
--- a/database/leveldb/leveldb.go
+++ b/database/leveldb/leveldb.go
@@ -143,7 +143,7 @@ func (db *Database) Get(key []byte) ([]byte, error) {
 	return dat, err
 }
 
-// Put inserts the given value into the key-value store.
+// Set inserts the given value into the key-value store.
 func (db *Database) Set(key []byte, value []byte) error {
 	return db.db.Put(wrapKey(db.namespace, key), value, nil)
 }
@@ -172,7 +172,7 @@ type batch struct {
 	size      int
 }
 
-// Put inserts the given value into the batch for later committing.
+// Set inserts the given value into the batch for later committing.
 func (b *batch) Set(key, value []byte) error {
 	b.b.Put(wrapKey(b.namespace, key), value)
 	b.size += len(value)

--- a/database/memory/memorydb.go
+++ b/database/memory/memorydb.go
@@ -105,7 +105,7 @@ type batch struct {
 	size   int
 }
 
-// Put inserts the given value into the batch for later committing.
+// Set inserts the given value into the batch for later committing.
 func (b *batch) Set(key, value []byte) error {
 	b.writes = append(b.writes, keyvalue{utils.CopyBytes(key), utils.CopyBytes(value), false})
 	b.size += len(value)

--- a/database/redis/redis.go
+++ b/database/redis/redis.go
@@ -138,7 +138,7 @@ func (db *Database) Get(key []byte) ([]byte, error) {
 	return utils.StringToBytes(dat), err
 }
 
-// Put inserts the given value into the key-value store.
+// Set inserts the given value into the key-value store.
 func (db *Database) Set(key []byte, value []byte) error {
 	return db.db.Set(context.Background(), wrapKey(db.namespace, key), value, 0).Err()
 }
@@ -167,7 +167,7 @@ type batch struct {
 	size      int
 }
 
-// Put inserts the given value into the batch for later committing.
+// Set inserts the given value into the batch for later committing.
 func (b *batch) Set(key, value []byte) error {
 	b.b.Set(context.Background(), wrapKey(b.namespace, key), value, 0)
 	b.size += len(value)

--- a/options.go
+++ b/options.go
@@ -52,3 +52,9 @@ func EnableMetrics(metrics metrics.Metrics) Option {
 		smt.metrics = metrics
 	}
 }
+
+func EnableKeyReadable(keyReadable bool) Option {
+	return func(smt *BNBSparseMerkleTree) {
+		smt.keyReadable = keyReadable
+	}
+}

--- a/tree_node.go
+++ b/tree_node.go
@@ -137,7 +137,7 @@ func (node *TreeNode) SetChildren(child *TreeNode, nibble int, version Version) 
 	})
 }
 
-// Recompute all internal hashes
+// ComputeInternalHash Recompute all internal hashes
 func (node *TreeNode) ComputeInternalHash() {
 	node.mu.Lock()
 	defer node.mu.Unlock()
@@ -253,7 +253,7 @@ func (node *TreeNode) PreviousVersion() Version {
 	return node.Versions[len(node.Versions)-2].Ver
 }
 
-// size returns the current node size
+// Size returns the current node size
 func (node *TreeNode) Size() uint64 {
 	if node.temporary {
 		return uint64(len(node.Versions) * versionSize)


### PR DESCRIPTION
### Description

Add a switch `keyReadable` to make the key of smt readable

### Rationale

the merkle tree node's key like as below
![image](https://github.com/bnb-chain/zkbnb-smt/assets/16110876/260de6c6-13c2-43c0-b985-46d5b5a61f48)

### Example

add an example CLI or API response...

### Changes
